### PR TITLE
Remove some C code and use Ruby instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.6.5
+  - 2.7.0
 git:
   depth: 10
 
@@ -22,7 +21,7 @@ os:
 matrix:
   include:
     - script: bundle exec rake rubocop
-      rvm: 2.5.0
+      rvm: 2.6.5
 
 env:
   -TREE_SITTER_PARSER_DIR=$TRAVIS_BUILD_DIR/test/tree-sitter/fixtures/parsers

--- a/ext/tree-sitter/document.c
+++ b/ext/tree-sitter/document.c
@@ -18,31 +18,6 @@ static VALUE rb_document_alloc(VALUE self)
 }
 
 /*
- * Public: Creates a new document
- *
- */
-VALUE rb_document_new(VALUE self, VALUE rb_input_string, VALUE rb_options)
-{
-  TSDocument *document;
-  VALUE rb_language;
-
-  Check_Type(rb_input_string, T_STRING);
-  Check_Type (rb_options, T_HASH);
-
-  rb_language = rb_hash_aref(rb_options, CSTR2SYM("language"));
-  Check_Type(rb_language, T_STRING);
-
-  Data_Get_Struct(self, TSDocument, document);
-
-  rb_document_set_language(self, rb_language);
-  rb_document_set_input_string(self, rb_input_string);
-  rb_document_parse(self);
-
-  return self;
-}
-
-
-/*
  * Public: Set the language type of a document.
  *
  * lang - A {String} identifying the language.
@@ -141,7 +116,6 @@ void init_document()
 
   VALUE rb_cDocument = rb_define_class_under(tree_sitter, "Document", rb_cObject);
   rb_define_alloc_func(rb_cDocument, rb_document_alloc);
-  rb_define_method(rb_cDocument, "initialize", rb_document_new, 2);
   rb_define_method(rb_cDocument, "language=", rb_document_set_language, 1);
   rb_define_method(rb_cDocument, "input_string=", rb_document_set_input_string, 1);
   rb_define_method(rb_cDocument, "parse", rb_document_parse, 0);

--- a/ext/tree-sitter/document.c
+++ b/ext/tree-sitter/document.c
@@ -51,7 +51,7 @@ static VALUE rb_document_set_language(VALUE self, VALUE ptr)
  *
  * Returns nothing.
  */
-VALUE rb_document_set_input_string(VALUE self, VALUE rb_input_string)
+static VALUE rb_document_set_input_string(VALUE self, VALUE rb_input_string)
 {
   TSDocument *document;
   Check_Type(rb_input_string, T_STRING);
@@ -69,7 +69,7 @@ VALUE rb_document_set_input_string(VALUE self, VALUE rb_input_string)
  *
  * Returns true if successful.
  */
-VALUE rb_document_parse(VALUE self)
+static VALUE rb_document_parse(VALUE self)
 {
   TSDocument *document;
 
@@ -85,7 +85,7 @@ VALUE rb_document_parse(VALUE self)
  *
  * Returns a {Node}.
  */
-VALUE rb_document_root_node(VALUE self)
+static VALUE rb_document_root_node(VALUE self)
 {
   TSDocument *document;
 
@@ -95,10 +95,8 @@ VALUE rb_document_root_node(VALUE self)
   return rb_new_node(ts_node, document);
 }
 
-void init_document()
+void init_document(VALUE tree_sitter)
 {
-  VALUE tree_sitter = rb_define_module("TreeSitter");
-
   rb_eDocumentError = rb_define_class_under(tree_sitter, "DocumentError", rb_eStandardError);
 
   VALUE rb_cDocument = rb_define_class_under(tree_sitter, "Document", rb_cObject);

--- a/ext/tree-sitter/document.h
+++ b/ext/tree-sitter/document.h
@@ -10,7 +10,6 @@ static VALUE rb_eDocumentError;
 void init_document();
 static VALUE rb_document_alloc(VALUE self);
 VALUE rb_document_new(VALUE self, VALUE rb_str, VALUE rb_options);
-VALUE rb_document_set_language(VALUE self, VALUE lang);
 VALUE rb_document_set_input_string(VALUE self, VALUE str);
 VALUE rb_document_parse(VALUE self);
 

--- a/ext/tree-sitter/document.h
+++ b/ext/tree-sitter/document.h
@@ -2,15 +2,10 @@
 #define RB_TREE_SITTER_DOCUMENT_H
 
 #include "ruby.h"
-#include <dlfcn.h>
 #include "tree-sitter.h"
 
 static VALUE rb_eDocumentError;
 
-void init_document();
-static VALUE rb_document_alloc(VALUE self);
-VALUE rb_document_new(VALUE self, VALUE rb_str, VALUE rb_options);
-VALUE rb_document_set_input_string(VALUE self, VALUE str);
-VALUE rb_document_parse(VALUE self);
+void init_document(VALUE);
 
 #endif

--- a/ext/tree-sitter/node.c
+++ b/ext/tree-sitter/node.c
@@ -21,7 +21,7 @@ VALUE rb_new_node(TSNode ts_node, TSDocument *ts_document)
  *
  * Returns a {String}.
  */
-VALUE rb_node_to_s(VALUE self)
+static VALUE rb_node_to_s(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -34,7 +34,7 @@ VALUE rb_node_to_s(VALUE self)
  *
  * Returns a {String}.
  */
-VALUE rb_node_type(VALUE self)
+static VALUE rb_node_type(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -52,7 +52,7 @@ void rb_point_free(void *p)
  *
  * Returns a {Point}.
  */
-VALUE rb_node_start_point(VALUE self)
+static VALUE rb_node_start_point(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -69,7 +69,7 @@ VALUE rb_node_start_point(VALUE self)
  *
  * Returns a {Point}.
  */
-VALUE rb_node_end_point(VALUE self)
+static VALUE rb_node_end_point(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -87,7 +87,7 @@ VALUE rb_node_end_point(VALUE self)
  *
  * Returns a {Boolean}.
  */
-VALUE rb_node_is_named(VALUE self)
+static VALUE rb_node_is_named(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -100,7 +100,7 @@ VALUE rb_node_is_named(VALUE self)
  *
  * Returns an {Integer}.
  */
-VALUE rb_node_child_count(VALUE self)
+static VALUE rb_node_child_count(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -117,7 +117,7 @@ VALUE rb_node_child_count(VALUE self)
  *
  * Returns an {Integer}.
  */
-VALUE rb_node_named_child_count(VALUE self)
+static VALUE rb_node_named_child_count(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -134,7 +134,7 @@ VALUE rb_node_named_child_count(VALUE self)
  *
  * Returns a {Node} or nil.
  */
-VALUE rb_node_first_child(VALUE self)
+static VALUE rb_node_first_child(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -153,7 +153,7 @@ VALUE rb_node_first_child(VALUE self)
  *
  * Returns a {Node} or nil.
  */
-VALUE rb_node_first_named_child(VALUE self)
+static VALUE rb_node_first_named_child(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -172,7 +172,7 @@ VALUE rb_node_first_named_child(VALUE self)
  *
  * Returns a {Node} or nil.
  */
-VALUE rb_node_last_child(VALUE self)
+static VALUE rb_node_last_child(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -191,7 +191,7 @@ VALUE rb_node_last_child(VALUE self)
  *
  * Returns a {Node} or nil.
  */
-VALUE rb_node_last_named_child(VALUE self)
+static VALUE rb_node_last_named_child(VALUE self)
 {
   AstNode *node;
   Data_Get_Struct(self, AstNode, node);
@@ -210,7 +210,7 @@ VALUE rb_node_last_named_child(VALUE self)
  *
  * Returns a {Node} or nil.
  */
-VALUE rb_node_child(VALUE self, VALUE child_index)
+static VALUE rb_node_child(VALUE self, VALUE child_index)
 {
   Check_Type(child_index, T_FIXNUM);
   uint32_t i = NUM2UINT(child_index);
@@ -233,7 +233,7 @@ VALUE rb_node_child(VALUE self, VALUE child_index)
  *
  * Returns a {Node} or nil.
  */
-VALUE rb_node_named_child(VALUE self, VALUE child_index)
+static VALUE rb_node_named_child(VALUE self, VALUE child_index)
 {
   Check_Type(child_index, T_FIXNUM);
   uint32_t i = NUM2UINT(child_index);
@@ -256,7 +256,7 @@ VALUE rb_node_named_child(VALUE self, VALUE child_index)
  *
  * Returns an {Integer}.
  */
-VALUE rb_point_row(VALUE self)
+static VALUE rb_point_row(VALUE self)
 {
   Point *point;
   Data_Get_Struct(self, Point, point);
@@ -268,17 +268,15 @@ VALUE rb_point_row(VALUE self)
  *
  * Returns an {Integer}.
  */
-VALUE rb_point_column(VALUE self)
+static VALUE rb_point_column(VALUE self)
 {
   Point *point;
   Data_Get_Struct(self, Point, point);
   return UINT2NUM(point->ts_point.column);
 }
 
-void init_node()
+void init_node(VALUE tree_sitter)
 {
-  VALUE tree_sitter = rb_define_module("TreeSitter");
-
   rb_cNode = rb_define_class_under(tree_sitter, "Node", rb_cObject);
   rb_define_method(rb_cNode, "to_s", rb_node_to_s, 0);
   rb_define_method(rb_cNode, "node_type", rb_node_type, 0);

--- a/ext/tree-sitter/node.c
+++ b/ext/tree-sitter/node.c
@@ -3,17 +3,12 @@
 VALUE rb_cNode;
 VALUE rb_cPoint;
 
-static void rb_node_free(void *n)
-{
-  free(n);
-}
-
 VALUE rb_new_node(TSNode ts_node, TSDocument *ts_document)
 {
-  AstNode *node = malloc(sizeof(AstNode));
+  AstNode *node = xmalloc(sizeof(AstNode));
   node->ts_node = ts_node;
   node->ts_document = ts_document;
-  return Data_Wrap_Struct(rb_cNode, NULL, rb_node_free, node);
+  return Data_Wrap_Struct(rb_cNode, NULL, xfree, node);
 }
 
 /*
@@ -42,11 +37,6 @@ static VALUE rb_node_type(VALUE self)
   return rb_str_new_cstr(ts_node_type(node->ts_node, node->ts_document));
 }
 
-void rb_point_free(void *p)
-{
-  free(p);
-}
-
 /*
  * Public: Get the starting position for a node.
  *
@@ -58,10 +48,10 @@ static VALUE rb_node_start_point(VALUE self)
   Data_Get_Struct(self, AstNode, node);
 
   TSPoint start = ts_node_start_point(node->ts_node);
-  Point *point = malloc(sizeof(Point));
+  Point *point = xmalloc(sizeof(Point));
   point->ts_point = start;
 
-  return Data_Wrap_Struct(rb_cPoint, NULL, rb_point_free, point);
+  return Data_Wrap_Struct(rb_cPoint, NULL, xfree, point);
 }
 
 /*
@@ -76,10 +66,10 @@ static VALUE rb_node_end_point(VALUE self)
 
   TSPoint start = ts_node_end_point(node->ts_node);
 
-  Point *point = malloc(sizeof(Point));
+  Point *point = xmalloc(sizeof(Point));
   point->ts_point = start;
 
-  return Data_Wrap_Struct(rb_cPoint, NULL, rb_point_free, point);
+  return Data_Wrap_Struct(rb_cPoint, NULL, xfree, point);
 }
 
 /*

--- a/ext/tree-sitter/node.h
+++ b/ext/tree-sitter/node.h
@@ -14,21 +14,8 @@ typedef struct point_type {
   TSPoint ts_point;
 } Point;
 
-void init_node();
+void init_node(VALUE);
 static void rb_node_free(void *n);
 VALUE rb_new_node(TSNode ts_node, TSDocument *ts_document);
-VALUE rb_node_to_s(VALUE self);
-VALUE rb_node_type(VALUE self);
-VALUE rb_node_start_point(VALUE self);
-VALUE rb_node_end_point(VALUE self);
-VALUE rb_node_is_named(VALUE self);
-VALUE rb_node_child_count(VALUE self);
-VALUE rb_node_named_child_count(VALUE self);
-VALUE rb_node_first_child(VALUE self);
-VALUE rb_node_first_named_child(VALUE self);
-VALUE rb_node_last_child(VALUE self);
-VALUE rb_node_last_named_child(VALUE self);
-VALUE rb_node_child(VALUE self, VALUE child_index);
-VALUE rb_node_named_child(VALUE self, VALUE child_index);
 
 #endif

--- a/ext/tree-sitter/tree-sitter.c
+++ b/ext/tree-sitter/tree-sitter.c
@@ -4,6 +4,6 @@ __attribute__((visibility("default"))) void Init_treesitter()
 {
   VALUE tree_sitter = rb_define_module("TreeSitter");
 
-  init_document();
-  init_node();
+  init_document(tree_sitter);
+  init_node(tree_sitter);
 }

--- a/lib/tree-sitter.rb
+++ b/lib/tree-sitter.rb
@@ -5,11 +5,13 @@ require 'tree-sitter/treesitter'
 require 'tree-sitter/version'
 require 'tree-sitter/node'
 
-begin
-  require 'awesome_print'
-  require 'pry'
-rescue LoadError; end
-
 module TreeSitter
-
+  class Document
+    def initialize(input_string, options)
+      language = options[:language]
+      self.language = language
+      self.input_string = input_string
+      self.parse
+    end
+  end
 end

--- a/lib/tree-sitter.rb
+++ b/lib/tree-sitter.rb
@@ -4,6 +4,7 @@
 require 'tree-sitter/treesitter'
 require 'tree-sitter/version'
 require 'tree-sitter/node'
+require 'fiddle'
 
 module TreeSitter
   class Document
@@ -12,6 +13,19 @@ module TreeSitter
       self.language = language
       self.input_string = input_string
       self.parse
+    end
+
+    # Public: Set the language type of a document.
+    #
+    # lang - A {String} identifying the language.
+    #
+    # Returns nothing.
+    def language=(lang)
+      handle = Fiddle.dlopen BUNDLE_PATH
+      function_address = handle[lang]
+      set_language function_address
+    rescue Fiddle::DLError
+      raise TreeSitter::DocumentError
     end
   end
 end

--- a/tree-sitter.gemspec
+++ b/tree-sitter.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib ext)
 
   spec.add_development_dependency 'awesome_print'
-  spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-focus', '~> 1.1'
   spec.add_development_dependency 'pry-byebug', '~> 3.6'


### PR DESCRIPTION
This PR removes some of the C code and replaces it with Ruby.  Most of the changes in this PR are just C hygiene changes, but the important part is that we've replaced the `initialize` method and `language=` method with a pure Ruby implementation.

This PR should be 100% backwards compatible with the existing implementation.  The [BUNDLE_PATH constant](https://github.com/tree-sitter/ruby-tree-sitter/compare/master...tenderlove:more-ruby?expand=1#diff-e2b4bd6695af981bf8ba107a8113b398R24) is defined at compile time, so this code will behave exactly the same way as the existing code -- including having the `BUNDLE_PATH` constant be hard coded to the compilation location.

However, I think the advantage of this patch is that we can more easily change the internals to search for the right locations for any shared objects and use them instead.  In other words, I think this will be much easier to modify.

cc @zackfern @reiddraper